### PR TITLE
remove asdf from zsh symlink

### DIFF
--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -23,9 +23,6 @@ else
 	. $HOME/.asdf/asdf.sh
 fi
 
-# Set asdf plugin settings
-. ~/.asdf/plugins/dotnet-core/set-dotnet-home.zsh
-
 # append asdf completions to fpath
 fpath=(${ASDF_DIR}/completions $fpath)
 # initialise completions with ZSH's compinit


### PR DESCRIPTION
This should be handled by the asdf install scripts. 